### PR TITLE
Skipping Clang 12

### DIFF
--- a/.github/workflows/build-and-install.yaml
+++ b/.github/workflows/build-and-install.yaml
@@ -145,7 +145,7 @@ jobs:
       - name: Compiling & linking gollvm
         run: cd $GITHUB_WORKSPACE/gollvm_build_process && mkdir build_min && cd build_min && cmake -DCMAKE_BUILD_TYPE=MinSizeRel -DLLVM_TARGETS_TO_BUILD=X86 -DCMAKE_C_COMPILER=clang-11 -DCMAKE_CXX_COMPILER=clang++-11 -G Ninja ../llvm-project/llvm && ninja -j16 gollvm && ninja GoBackendCoreTests && ./tools/gollvm/unittests/BackendCore/GoBackendCoreTests
 #Clang 12 and 13 are still not available        
-  clang12_build_minsizerel: #The build with a minimal footprint?
+  clang13_build_minsizerel: #The build with a minimal footprint?
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
@@ -158,9 +158,9 @@ jobs:
       - name: Check our path
         run: pwd
       - name: Extracting llc's host target
-        run: llc-12 --version | grep CPU
+        run: llc --version | grep CPU
       - name: Compile test tool, for retrieveing CPU features
-        run: clang-12 -I/usr/lib/llvm-12/include/ -I/usr/lib/llvm-12/include/llvm-c -L/usr/lib/llvm-12/lib -lLLVM-12 -lstdc++ $GITHUB_WORKSPACE/gollvm_build_process/llvm_cpu_features_investigation.cpp
+        run: clang -I/usr/lib/llvm-12/include/ -I/usr/lib/llvm-12/include/llvm-c -L/usr/lib/llvm-12/lib -lLLVM-12 -lstdc++ $GITHUB_WORKSPACE/gollvm_build_process/llvm_cpu_features_investigation.cpp
       - name: Run the CPU feature extractor
         run: ./a.out
       - name: Trying to check if we could install Ninja
@@ -171,28 +171,4 @@ jobs:
         run:  cd $GITHUB_WORKSPACE/gollvm_build_process && git clone https://github.com/llvm/llvm-project.git && cd llvm-project/llvm/tools && git clone https://go.googlesource.com/gollvm &&  cd gollvm && git clone https://go.googlesource.com/gofrontend && cd libgo && git clone https://github.com/libffi/libffi.git && git clone https://github.com/ianlancetaylor/libbacktrace.git
       - name: Compiling & linking gollvm
         run: cd $GITHUB_WORKSPACE/gollvm_build_process && mkdir build_min && cd build_min && cmake -DCMAKE_BUILD_TYPE=MinSizeRel -DLLVM_TARGETS_TO_BUILD=X86 -DCMAKE_C_COMPILER=clang-12 -DCMAKE_CXX_COMPILER=clang++-12 -G Ninja ../llvm-project/llvm && ninja -j16 gollvm && ninja GoBackendCoreTests && ./tools/gollvm/unittests/BackendCore/GoBackendCoreTests
-  clang13_build_minsizerel: #The build with a minimal footprint?
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: actions/checkout@v2
-      - name: Install Clang 13, using dpkg
-        run: wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && sudo ./llvm.sh 13
-      - name: Check if Clang 13 is on board
-        run: which clang-13
-      - name: Check our path
-        run: pwd
-      - name: Extracting llc's host target
-        run: llc-13 --version | grep CPU
-      - name: Compile test tool, for retrieveing CPU features
-        run: clang-13 -I/usr/lib/llvm-13/include/ -I/usr/lib/llvm-13/include/llvm-c -L/usr/lib/llvm-13/lib -lLLVM-13 -lstdc++ $GITHUB_WORKSPACE/gollvm_build_process/llvm_cpu_features_investigation.cpp
-      - name: Run the CPU feature extractor
-        run: ./a.out
-      - name: Trying to check if we could install Ninja
-        run: sudo apt install ninja-build -y
-      - name: Checking the version of make, automake, autoconf, m4 and Ninja
-        run: make --version && m4 --version && autoconf --version && automake --version && echo "Ninja's version is" && ninja --version
-      - name: Clonning LLVM master branch && gollvm related repos.
-        run:  cd $GITHUB_WORKSPACE/gollvm_build_process && git clone https://github.com/llvm/llvm-project.git && cd llvm-project/llvm/tools && git clone https://go.googlesource.com/gollvm &&  cd gollvm && git clone https://go.googlesource.com/gofrontend && cd libgo && git clone https://github.com/libffi/libffi.git && git clone https://github.com/ianlancetaylor/libbacktrace.git
-      - name: Compiling & linking gollvm
-        run: cd $GITHUB_WORKSPACE/gollvm_build_process && mkdir build_min && cd build_min && cmake -DCMAKE_BUILD_TYPE=MinSizeRel -DLLVM_TARGETS_TO_BUILD=X86 -DCMAKE_C_COMPILER=clang-13 -DCMAKE_CXX_COMPILER=clang++-13 -G Ninja ../llvm-project/llvm && ninja -j16 gollvm && ninja GoBackendCoreTests && ./tools/gollvm/unittests/BackendCore/GoBackendCoreTests
   


### PR DESCRIPTION
Since Clang 13 is the current target within LLVM's master branch.
Fixed llc's invocation command